### PR TITLE
Add nodeValue

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,12 +50,21 @@ Node.prototype = {
             return child[ child.nodeType == 3 ? "data" : "textContent" ]
         }).join("") : this.nodeType === 3 ? this.data : ""
 	},
-    nodeValue: this.data,
 	set textContent(text) {
 		if(this.nodeType === 3) return this.data = text
 		for (var self = this; self.firstChild;) self.removeChild(self.firstChild)
 		self.appendChild(self.ownerDocument.createTextNode(text))
 	},
+    get nodeValue() {
+        return this.hasChildNodes() ? this.childNodes.map(function(child){
+            return child[ child.nodeType == 3 ? "data" : "textContent" ]
+        }).join("") : this.nodeType === 3 ? this.data : ""
+    },
+    set nodeValue(text) {
+        if(this.nodeType === 3) return this.data = text
+        for (var self = this; self.firstChild;) self.removeChild(self.firstChild)
+        self.appendChild(self.ownerDocument.createTextNode(text))
+    },
 	get firstChild() {
 		return this.childNodes && this.childNodes[0] || null
 	},


### PR DESCRIPTION
I use nodeValue a lot in my app.  

https://developer.mozilla.org/en-US/docs/Web/API/Node.nodeValue

I see that nodeValue and textElement are very similar.  A query on github comes up with 2.8 million+ usages for nodeValue vs 1.8 million for textContent.  Due to the widespread use of this, I wanted to add to dom-lite.  Due to dom-lite being a lightweight library, the differences between nodeValue and textElement are so minimal, that it is moot for this library.  Therefore, the best implementation is just a reference or copy of textElement.  I chose a direct copy, because I couldn't figure out how to reference a getter or setter.  (ie nodeValue: get this.textElement()

This leads to a small amount of code duplication.  However, the other way of writing this could be done by creating two functions

function setText(){
    return this.hasChildNodes() ? this.childNodes.map(function(child){
        return child[ child.nodeType == 3 ? "data" : "textContent" ]
    }).join("") : this.nodeType === 3 ? this.data : ""
}

function getText(text){
    if(this.nodeType === 3) return this.data = text
    for (var self = this; self.firstChild;) self.removeChild(self.firstChild)
    self.appendChild(self.ownerDocument.createTextNode(text))
}

then calling them like this

```
get textContent() {
    return getText.call(this);
},
set textContent(text) {
    setText.call(this, text);
},
get nodeValue() {
    return getText.call(this);
},
set nodeValue(text) {
    setText.call(this, text);
},
```

less duplication, but also more bloat and harder to understand
