### PR TITLE
Fixed non-string data issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -305,6 +305,18 @@ extend(Text, Node, {
 	nodeName: "#text"
 })
 
+Object.defineProperty(Text.prototype, 'data', {
+  get: function() { return this.__data__; },
+  set: function(data) {
+  	if(data == null){
+		data = '';
+	}
+	this.__data__ = '' + data;
+  },
+  enumerable: true,
+  configurable: true
+});
+
 function Comment(data) {
 	this.data = data
 }
@@ -316,6 +328,18 @@ extend(Comment, Node, {
 		return "<!--" + this.data + "-->"
 	}
 })
+
+Object.defineProperty(Comment.prototype, 'data', {
+  get: function() { return this.__data__; },
+  set: function(data) {
+  	if(data == null){
+		data = '';
+	}
+	this.__data__ = '' + data;
+  },
+  enumerable: true,
+  configurable: true
+});
 
 function Document(){
 	this.body = this.createElement("body")

--- a/tests/index.js
+++ b/tests/index.js
@@ -309,3 +309,12 @@ test("getElementById, getElementsByTagName, querySelector", function (assert) {
     assert.end()
 })
 
+test("testNode.data", function (assert) {
+    var textNode = document.createTextNode('foo')
+
+    textNode.data = null;
+
+    assert.equal(textNode.data, '')
+
+    assert.end()
+})


### PR DESCRIPTION
var textNode = document.createTextNode('');

textNode.data = 123;

textNode.toString(); // Errors due to data not being a string.
