### PR TITLE
Export DocumentFragment

### DIFF
--- a/index.js
+++ b/index.js
@@ -410,6 +410,7 @@ module.exports = {
 	StyleMap: StyleMap,
 	Node: Node,
 	HTMLElement: HTMLElement,
+	DocumentFragment: DocumentFragment,
 	Document: Document
 }
 


### PR DESCRIPTION
Useful when testing an implementation of a JSX that creates elements using DOM API. `<>...</>` gets converted to `createEl(DocumentFragment, ...)`. Making `document` and `DocumentFragment` global identifiers allows using `dom-lite` for unit tests in `node`.

Another case is adding a shadow DOM implementation with `ShadowRoot`  inherited from `DocumentFragment`.